### PR TITLE
Update to 4.0.0-0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Bitnami <containers@bitnami.com>
 
 ENV BITNAMI_APP_NAME=node \
     BITNAMI_APP_USER=bitnami \
-    BITNAMI_APP_VERSION=0.12.6-1 \
+    BITNAMI_APP_VERSION=4.0.0-0 \
     BITNAMI_APP_DIR=$BITNAMI_PREFIX/nodejs
 
 ENV PATH=$BITNAMI_PREFIX/python/bin:$BITNAMI_APP_DIR/bin:$BITNAMI_PREFIX/common/bin:$PATH

--- a/installer.run.sha256
+++ b/installer.run.sha256
@@ -1,1 +1,1 @@
-88e838b3ee5ac06258a233a7c1b500bd0718c3bfc990347899b6c3abb7d70419 /tmp/installer.run
+58ea178dbaf6bad30ba7fe45aeb32e43860536fcf58955ef1cb6ba1feac2f370 /tmp/installer.run


### PR DESCRIPTION
Note, test fails due to imagemagic-native. Seems to be the following issue:
https://github.com/mash/node-imagemagick-native/issues/88