### PR TITLE
fix for docker-compose command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ docker run -it --name node bitnami/node
 ## Docker Compose
 
 ```bash
-$ curl -sSL https://raw.githubusercontent.com/bitnami/bitnami-docker-mariadb/master/docker-compose.yml > docker-compose.yml
+$ curl -sSL https://raw.githubusercontent.com/bitnami/bitnami-docker-node/master/docker-compose.yml > docker-compose.yml
 $ docker-compose up -d
 ```
 


### PR DESCRIPTION
**Description of the change**

Changed the command that is used to get docker-compose file as it was getting the docker-compose of mariadb instead of node.
